### PR TITLE
Primary contact automation

### DIFF
--- a/force-app/main/default/classes/Job_Application_Trigger_Handler.cls
+++ b/force-app/main/default/classes/Job_Application_Trigger_Handler.cls
@@ -8,11 +8,24 @@ Created Date       : July 2024
 */
 
 public with sharing class Job_Application_Trigger_Handler extends TriggerHandler{
+    public override void beforeInsert(){
+        if(!isBypassed('beforeInsert')){
+            Job_Application_Utility.setPrimaryContact(trigger.new);
+        }
+    }
+
+    public override void beforeUpdate(){
+        if(!isBypassed('beforeUpdate')){
+            Job_Application_Utility.setPrimaryContact(trigger.new);
+        }
+    }
+    
     public override void afterInsert(){
         if(!isBypassed('afterInsert')){
             Job_Application_Utility.createJobApplicationTasks(trigger.new);
         }
     }
+
     public override void afterUpdate(){
         if(!isBypassed('afterUpdate')){
             Job_Application_Utility.createJobApplicationTasks(trigger.new);

--- a/force-app/main/default/classes/Job_Application_Utility.cls
+++ b/force-app/main/default/classes/Job_Application_Utility.cls
@@ -92,57 +92,74 @@ public with sharing class Job_Application_Utility {
 @description    : set the primary contact on the job application if the primary contact is null 
                 and there is at least one related contact. Use the first contact available in the 
                 contact-related list or the first contact related to the Company(Account).
-@param          : List of Job_Applicaiton__c records from trigger.new
+@param  List<Job_Application__c> jobApplications: List of Job_Applicaiton__c records from Trigger.new
 @return         : contactId
 ********************************************************
 */
     public static void setPrimaryContact(List<Job_Application__c> jobApplications){
-        system.debug('Start setPrimaryContact');
+        
+        Set<Id> jobAppIds = new Set<Id>();
+        Set<Id> accountIds = new Set<Id>();
+
+        //collect job Applications and Account ids
         for(Job_Application__c jobApplication : jobApplications){
             if(jobApplication.Primary_Contact__c == null){
-                //find contact in Job_Application_Contact__c
-                Id contactId = jobApplicationContactContactId(jobApplication.Id);
-                if(contactId != null){
-                jobApplication.Primary_Contact__c = contactId;
+                jobAppIds.add(jobApplication.Id);
+                
+                if(jobApplication.Company_Name__c != null){
+                    accountIds.add(jobApplication.Company_Name__c);
                 }
             }
+        }
+        // Map to store the first created Job_Application_Contact__c for each Job_Application__c
+        Map<Id, Id> jobAppContactMap = new Map<Id, Id>();
+        // Query related Job_Application_Contact__c records
+        List<Job_Application_Contact__c> jobAppContacts = [
+            SELECT Job_Application__c, Contact__c
+            FROM Job_Application_Contact__c
+            WHERE Job_Application__c IN :jobAppIds
+            ORDER BY CreatedDate ASC
+        ];
+    
+        // Populate the map with the first created Job Application Contact for each Job_Application__c
+        for (Job_Application_Contact__c jobAppContact : jobAppContacts) {
+            if (!jobAppContactMap.containsKey(jobAppContact.Job_Application__c)) {
+                jobAppContactMap.put(jobAppContact.Job_Application__c, jobAppContact.Contact__c);
+            }
+        }
 
-            if(jobApplication.Primary_Contact__c == null && jobApplication.Company_Name__c != null){
-                //find contact from Account(company_name__c) if primary_contact__c still null
-                Id contactId = jobApplicationCompanyContact(jobApplication.Company_Name__c);
-                if(contactId != null){
+        // Map to store the first created contact for each Account
+        Map<Id, Id> accountContactMap = new Map<Id, Id>();
+        if (!accountIds.isEmpty()) {
+            // Query related contacts for the accounts
+            List<Contact> contacts = [
+                SELECT Id, AccountId
+                FROM Contact
+                WHERE AccountId IN :accountIds
+                ORDER BY CreatedDate ASC
+            ];
+            // Populate the map with the first created contact for each Account
+            for (Contact contact : contacts) {
+                if (!accountContactMap.containsKey(contact.AccountId)) {
+                    accountContactMap.put(contact.AccountId, contact.Id);
+                }
+            }
+        }
+        // Set Primary_Contact__c for each job application if it is currently null
+        for (Job_Application__c jobApplication : jobApplications) {
+            if (jobApplication.Primary_Contact__c == null) {
+                // Check if there's a related Job_Application_Contact__c record
+                Id contactId = jobAppContactMap.get(jobApplication.Id);
+                if (contactId != null) {
                     jobApplication.Primary_Contact__c = contactId;
+                } else if (jobApplication.Company_Name__c != null) {
+                    // If no Job_Application_Contact__c record found, check related contacts for the account
+                    contactId = accountContactMap.get(jobApplication.Company_Name__c);
+                    if (contactId != null) {
+                        jobApplication.Primary_Contact__c = contactId;
+                    }
                 }
             }
         }
     }
-    //helper method to  find contact in Job_Application_Contact__c
-    private static Id jobApplicationContactContactId(Id jobAppId){
-        system.debug('Start jobApplicationContactContactId');
-            List<Job_Application_Contact__c> jobAppContacts = [SELECT Contact__c
-                                                        FROM Job_Application_Contact__c
-                                                        WHERE Job_Application__c = :jobAppId
-                                                        ORDER BY CreatedDate asc
-                                                        LIMIT 1];
-            
-            if(!jobAppContacts.isEmpty()){
-                Id contactId = jobAppContacts[0].Contact__c;
-                return contactId;
-            }
-            return null;
-    }
-        //helper method to  find contact related to Account (Company_Name__c)
-        private static Id jobApplicationCompanyContact(Id accountId){
-            system.debug('Start jobApplicationCompanyContact');
-                List<Contact> contacts = [SELECT Id
-                                            FROM Contact
-                                            WHERE AccountId = :accountId
-                                            ORDER BY CreatedDate asc
-                                            LIMIT 1];
-                if(!contacts.isEmpty()){
-                    Id contactId = contacts[0].Id;
-                    return contactId;
-                }                       
-                return null;
-        }
 }

--- a/force-app/main/default/classes/Job_Application_Utility.cls
+++ b/force-app/main/default/classes/Job_Application_Utility.cls
@@ -85,4 +85,64 @@ public with sharing class Job_Application_Utility {
         newTask.ActivityDate = system.today()+daysUntilDue;
         return newTask;
     }
+    /*
+*********************************************************
+@Method Name    : setPrimaryContact
+@author         : Steven Trumble
+@description    : set the primary contact on the job application if the primary contact is null 
+                and there is at least one related contact. Use the first contact available in the 
+                contact-related list or the first contact related to the Company(Account).
+@param          : List of Job_Applicaiton__c records from trigger.new
+@return         : contactId
+********************************************************
+*/
+    public static void setPrimaryContact(List<Job_Application__c> jobApplications){
+        system.debug('Start setPrimaryContact');
+        for(Job_Application__c jobApplication : jobApplications){
+            if(jobApplication.Primary_Contact__c == null){
+                //find contact in Job_Application_Contact__c
+                Id contactId = jobApplicationContactContactId(jobApplication.Id);
+                if(contactId != null){
+                jobApplication.Primary_Contact__c = contactId;
+                }
+            }
+
+            if(jobApplication.Primary_Contact__c == null && jobApplication.Company_Name__c != null){
+                //find contact from Account(company_name__c) if primary_contact__c still null
+                Id contactId = jobApplicationCompanyContact(jobApplication.Company_Name__c);
+                if(contactId != null){
+                    jobApplication.Primary_Contact__c = contactId;
+                }
+            }
+        }
+    }
+    //helper method to  find contact in Job_Application_Contact__c
+    private static Id jobApplicationContactContactId(Id jobAppId){
+        system.debug('Start jobApplicationContactContactId');
+            List<Job_Application_Contact__c> jobAppContacts = [SELECT Contact__c
+                                                        FROM Job_Application_Contact__c
+                                                        WHERE Job_Application__c = :jobAppId
+                                                        ORDER BY CreatedDate asc
+                                                        LIMIT 1];
+            
+            if(!jobAppContacts.isEmpty()){
+                Id contactId = jobAppContacts[0].Contact__c;
+                return contactId;
+            }
+            return null;
+    }
+        //helper method to  find contact related to Account (Company_Name__c)
+        private static Id jobApplicationCompanyContact(Id accountId){
+            system.debug('Start jobApplicationCompanyContact');
+                List<Contact> contacts = [SELECT Id
+                                            FROM Contact
+                                            WHERE AccountId = :accountId
+                                            ORDER BY CreatedDate asc
+                                            LIMIT 1];
+                if(!contacts.isEmpty()){
+                    Id contactId = contacts[0].Id;
+                    return contactId;
+                }                       
+                return null;
+        }
 }

--- a/force-app/main/default/classes/Job_Application_Utility_Test.cls
+++ b/force-app/main/default/classes/Job_Application_Utility_Test.cls
@@ -3,7 +3,13 @@ This class contains unit tests for validating behvaioiur of logic in Job_Applica
 */
 @IsTest
 private class Job_Application_Utility_Test {
-
+    /*
+*********************************************************
+@Method Tested    : createJobApplicationTasks
+@author           : Steven Trumble
+@description      : test various scenarios that could occur for createJobApplicationTasks()
+********************************************************
+*/
     @isTest
     static void createJobApplicationNullStatus(){
         
@@ -457,4 +463,188 @@ private class Job_Application_Utility_Test {
         
         System.assertEquals(JOB_APPLICATIONS_TO_CREATE * EXPECTED_TASKS_PER_JOB_APPLICATION , taskCount, 'Expected 900 tasks to be created');
     }
+
+    /*
+*********************************************************
+@Method Tested    : setPrimaryContact
+@author           : Steven Trumble
+@description      : test various scenarios that could occur for setPrimaryContact()
+                    JAC = Job_Application_Contact__c
+********************************************************
+*/
+    @isTest
+    static void testJobApplicationPrimaryContactExists(){
+        Job_Application__c jobApp = TestDataFactory.createJobApplications(1)[0];
+        Contact existingContact = TestDataFactory.getContact(jobApp.Company_Name__c, 'Test', 'LastName', true);
+        jobApp.Primary_Contact__c = existingContact.Id;
+        update jobApp;
+        
+        // Call the utility method to set primary contact
+        Job_Application_Utility.setPrimaryContact(new List<Job_Application__c>{ jobApp });
+
+        // Retrieve the job application again to verify Primary_Contact__c
+        jobApp = [SELECT Id, Primary_Contact__c FROM Job_Application__c WHERE Id = :jobApp.Id];
+
+        // Assert that Primary_Contact__c remains unchanged
+        System.assertEquals(existingContact.Id, jobApp.Primary_Contact__c, 'Primary contact should not be overwritten');
+        System.assertNotEquals(existingContact.Id, null, 'Primary Contact should not be null');
+    }
+    
+    @isTest
+    static void testJobApplicationPrimaryContactNullJACExists() {
+        // Create a job application
+        Job_Application__c jobApp = TestDataFactory.createJobApplications(1)[0];
+        System.debug('Job Application: ' + jobApp);
+    
+        // Create a contact associated through Job_Application_Contact__c
+        Contact contact = TestDataFactory.getContact(null, 'Test', 'LastName', true);
+        System.debug('Contact: ' + contact);
+    
+        Job_Application_Contact__c jobAppContact = TestDataFactory.createJobApplicationContact(contact.Id, jobApp.Id);
+        System.debug('Job Application Contact: ' + jobAppContact);
+    
+        // Call the utility method to set primary contact
+        Test.startTest();
+            Job_Application_Utility.setPrimaryContact(new List<Job_Application__c>{ jobApp });
+            update jobApp;
+        Test.stopTest();
+    
+        // Retrieve the job application again to verify Primary_Contact__c
+        jobApp = [SELECT Id, Primary_Contact__c FROM Job_Application__c WHERE Id = :jobApp.Id];
+        System.debug('Updated Job Application: ' + jobApp);
+    
+        // Assert that Primary_Contact__c is set to the contact from Job_Application_Contact__c
+        System.assertEquals(contact.Id, jobApp.Primary_Contact__c, 'Primary contact should be set from Job_Application_Contact__c');
+    }
+
+    @isTest
+    static void testPrimaryContactNullNoJACCompanyContactExists() {
+        // Create a company (Account) with related contacts
+        Account companyAccount = TestDataFactory.getAccount('Test Company', true);
+        Contact companyContact = TestDataFactory.getContact(companyAccount.Id, 'Test', 'LastName', true);
+
+        // Create a job application with Company_Name__c set
+        Job_Application__c jobApp = new Job_Application__c(Company_Name__c = companyAccount.Id);
+        insert jobApp;
+
+        // Call the utility method to set primary contact
+        Job_Application_Utility.setPrimaryContact(new List<Job_Application__c>{ jobApp });
+
+        // Retrieve the job application again to verify Primary_Contact__c
+        jobApp = [
+            SELECT Id, Primary_Contact__c 
+            FROM Job_Application__c 
+            WHERE Id = :jobApp.Id
+            ];
+
+        // Query for the first contact related to the Company_Name__c
+        List<Contact> companyContacts = [
+            SELECT Id 
+            FROM Contact 
+            WHERE AccountId = :companyAccount.Id 
+            ORDER BY CreatedDate ASC 
+            LIMIT 1
+            ];
+
+        // Assert that Primary_Contact__c is set to the first contact's Id
+        System.assertEquals(companyContacts[0].Id, jobApp.Primary_Contact__c, 'Primary contact should be set from Company_Name__c contacts');
+    }
+
+    @isTest
+    static void testPrimaryContactNullNoJACNoCompanyContacts() {
+        // Create a company (Account) without any related contacts
+        Account companyAccount = TestDataFactory.getAccount('Test Company', true);
+
+        // Create a job application with Company_Name__c set
+        Job_Application__c jobApp = new Job_Application__c(Company_Name__c = companyAccount.Id);
+        insert jobApp;
+
+        // Call the utility method to set primary contact
+        Job_Application_Utility.setPrimaryContact(new List<Job_Application__c>{ jobApp });
+
+        // Retrieve the job application again to verify Primary_Contact__c
+        jobApp = [SELECT Id, Primary_Contact__c FROM Job_Application__c WHERE Id = :jobApp.Id];
+
+        // Assert that Primary_Contact__c remains null
+        System.assertEquals(null, jobApp.Primary_Contact__c, 'Primary contact should remain null when no contacts are associated');
+    }
+
+    @isTest
+    static void testPrimaryContactNullNoJACCompanyNull() {
+        // Create a job application with Company_Name__c set to null
+        Job_Application__c jobApp = new Job_Application__c();
+        insert jobApp;
+
+        // Call the utility method to set primary contact
+        Job_Application_Utility.setPrimaryContact(new List<Job_Application__c>{ jobApp });
+
+        // Retrieve the job application again to verify Primary_Contact__c
+        jobApp = [SELECT Id, Primary_Contact__c FROM Job_Application__c WHERE Id = :jobApp.Id];
+
+        // Assert that Primary_Contact__c remains null
+        System.assertEquals(null, jobApp.Primary_Contact__c, 'Primary contact should remain null when Company_Name__c is null and no existing Job_Application_Contact__c records');
+    }
+
+    @isTest
+    static void testBulkSetPrimaryContact() {
+        // Create a list of job applications with different scenarios
+        List<Job_Application__c> jobApps = new List<Job_Application__c>();
+
+        // Scenario 1: Primary_Contact__c is null, Associated Job_Application_Contact__c record exists
+        Job_Application__c jobApp1 = TestDataFactory.createJobApplications(1)[0];
+        Contact existingContact1 = TestDataFactory.getContact(null, 'Test1', 'LastName1', true);
+        Job_Application_Contact__c jobAppContact1 = TestDataFactory.createJobApplicationContact(existingContact1.Id,jobApp1.Id);
+        jobApp1.Primary_Contact__c = null; // Ensure Primary_Contact__c is null
+        jobApps.add(jobApp1);
+
+        // Scenario 2: Primary_Contact__c is null, No associated Job_Application_Contact__c, Company_Name__c has contacts
+        Job_Application__c jobApp2 = TestDataFactory.createJobApplications(1)[0];
+        Account account2 = TestDataFactory.getAccount('Test Company2', true); // Create an Account with contacts
+        Contact existingContact2 = TestDataFactory.getContact(account2.Id, 'Test2', 'LastName2', true);
+        jobApp2.Primary_Contact__c = null; // Ensure Primary_Contact__c is null
+        jobApp2.Company_Name__c = account2.Id;
+        jobApps.add(jobApp2);
+
+        // Scenario 3: Primary_Contact__c is null, No associated Job_Application_Contact__c, Company_Name__c has no contacts
+        Job_Application__c jobApp3 = TestDataFactory.createJobApplications(1)[0];
+        jobApp3.Company_Name__c = TestDataFactory.getAccount('Test Company3', true).Id; // Company_Name__c without contacts
+        jobApp3.Primary_Contact__c = null; // Ensure Primary_Contact__c is null
+        jobApps.add(jobApp3);
+
+        // Scenario 4: Primary_Contact__c is null, No associated Job_Application_Contact__c, Company_Name__c is null
+        Job_Application__c jobApp4 = TestDataFactory.createJobApplications(1)[0];
+        jobApp4.Company_Name__c = null; // Company_Name__c is null
+        jobApp4.Primary_Contact__c = null; // Ensure Primary_Contact__c is null
+        jobApps.add(jobApp4);
+
+        // Call the utility method to set primary contacts in bulk
+        Test.startTest();
+        Job_Application_Utility.setPrimaryContact(jobApps);
+        update jobApps;
+        Test.stopTest();
+
+        // Retrieve the job applications again to verify Primary_Contact__c
+        Map<Id, Job_Application__c> jobAppMap = new Map<Id, Job_Application__c>([
+            SELECT Id, Primary_Contact__c 
+            FROM Job_Application__c 
+            WHERE Id IN :jobApps
+        ]);
+
+        // Perform assertions
+
+        // Scenario 1: Ensure Primary_Contact__c is set to the existing contact from Job_Application_Contact__c
+        System.assertEquals(existingContact1.Id, jobAppMap.get(jobApp1.Id).Primary_Contact__c, 'Scenario 1: Primary contact should be set from Job_Application_Contact__c');
+
+        // Scenario 2: Ensure Primary_Contact__c is set to the existing contact from Company_Name__c
+        System.assertEquals(existingContact2.Id, jobAppMap.get(jobApp2.Id).Primary_Contact__c, 'Scenario 2: Primary contact should be set from contacts related to Company_Name__c');
+
+        // Scenario 3: Ensure Primary_Contact__c remains null as Company_Name__c has no contacts
+        System.assertEquals(null, jobAppMap.get(jobApp3.Id).Primary_Contact__c, 'Scenario 3: Primary contact should remain null when Company_Name__c has no contacts and no Job_Application_Contact__c records');
+
+        // Scenario 4: Ensure Primary_Contact__c remains null as Company_Name__c is null
+        System.assertEquals(null, jobAppMap.get(jobApp4.Id).Primary_Contact__c, 'Scenario 4: Primary contact should remain null when Company_Name__c is null and no Job_Application_Contact__c records');
+    }        
 }
+    
+
+    //bulk processsing with mixed scenarios in list

--- a/force-app/main/default/classes/TestDataFactory.cls
+++ b/force-app/main/default/classes/TestDataFactory.cls
@@ -28,4 +28,127 @@ public class TestDataFactory {
         insert jobApplications;
         return jobApplications;
     }
+
+/*
+*********************************************************
+@Method Names    : getAccount
+@author         : Steven Trumble
+@description    : methods used to create single account
+@param String name: name of account
+@param Boolean doInsert : whether to insert the account or not
+@return         : account
+********************************************************
+*/
+    public static Account getAccount(String name, Boolean doInsert) {
+        Account a = new Account(name = name);
+        if(doInsert) {
+            insert a;
+        }
+        return a;
+    }
+    /*
+*********************************************************
+@Method Names    : getContact
+@author         : Steven Trumble
+@description    : methods used to create single contact
+@param Id accountId: Id of related account
+@param String fname: first name of contact
+@param String lname: last name of contact
+@param Boolean doInsert : whether to insert the contact or not
+@return         : contact
+********************************************************
+*/
+    public static Contact getContact(
+        Id accountId,
+        String fname,
+        String lname,
+        Boolean doInsert
+    ) {
+        Contact c = new Contact(firstName = fname, lastName = lname, accountId = accountId);
+        if(doInsert) {
+            insert c;
+        }
+        return c;
+    }
+       /*
+*********************************************************
+@Method Names    : generateAccountWithContacts
+@author         : Steven Trumble
+@description    : methods used to create an account with a specified number of related contacts
+@param Integer numContacts: number of contacts to create related to the account
+@return         : contacts
+********************************************************
+*/
+    public static void generateAccountWithContacts(Integer numContacts) {
+        Account a = getAccount('default account ltd', true);
+        List<Contact> contacts = new List<Contact>();
+        for(Integer i = 0; i < numContacts; i++) {
+            String contactName = 'contact' + i;
+            contacts.add(getContact(a.id, contactName, contactName, false));
+        }
+        insert contacts;
+    }
+/*
+*********************************************************
+@Method Name    : createJobApplications
+@author         : Steven Trumble
+@description    : method to is used to create Job Application(s)
+@param Integer numJobApplications: number of job applications that need tasks created
+@return         : List of inserted Job Applications
+********************************************************
+*/    
+    public static List<Job_Application__c> createJobApplications(Integer numJobApplications) {
+        List<Job_Application__c> jobApplications = new List<Job_Application__c>();
+        for (Integer i = 0; i < numJobApplications; i++){
+            Job_Application__c jobApplication = new Job_Application__c();
+            jobApplications.add(jobApplication);
+        }
+        insert jobApplications;
+        return jobApplications;
+    }
+/*
+*********************************************************
+@Method Name    : createJobApplicationContact
+@author         : Steven Trumble
+@description    : method to is used to create Job Application Contact
+@param Id contactId: contact Id to use in the Contact__c field
+@param Id jobAppId: Job_Application__c Id to use in the Job_Application__c field
+@return         : Job_Application_Contact__c
+********************************************************
+*/    
+    public static Job_Application_Contact__c createJobApplicationContact(
+        Id contactId,
+        Id jobAppId
+    ) {
+        Job_Application_Contact__c jobApplicationContact = new Job_Application_Contact__c(Contact__c = contactId, Job_Application__c = jobAppId);
+        
+        insert jobApplicationContact;
+        return jobApplicationContact;
+    }
+
+/*
+*********************************************************
+@Method Name    : createJobApplicationWithAccountAndContacts
+@author         : Steven Trumble
+@description    : method to create Job Application(s) with related Account and Contacts
+@param Integer numJobApplications: number of job applications to create
+@param Integer numContacts: number of contacts per job application
+@return         : List of inserted Job Applications
+********************************************************
+*/    
+    public static List<Job_Application__c> createJobApplicationWithAccountAndContacts(Integer numJobApplications, Integer numContacts) {
+        List<Job_Application__c> jobApplications = new List<Job_Application__c>();
+        for (Integer i = 0; i < numJobApplications; i++){
+            Account account = getAccount('Account ' + i, true);
+            List<Contact> contacts = new List<Contact>();
+            for (Integer j = 0; j < numContacts; j++) {
+                contacts.add(getContact(account.Id, 'Contact' + j, 'Test', false));
+            }
+            insert contacts;
+            Job_Application__c jobApplication = new Job_Application__c(Company_Name__c = account.Id);
+            jobApplications.add(jobApplication);
+        }
+        insert jobApplications;
+        return jobApplications;
+    }
 }


### PR DESCRIPTION
all logic, tests and data factories to meet requirements for 
"Create automation to set the primary contact on the job application if the primary contact is null and there is at least one related contact. Use the first contact available in the contact-related list or the first contact related to the Company(Account)."